### PR TITLE
Add rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ textlint --preset track README.md
 - [読点は1文中に3つまで](#%E8%AA%AD%E7%82%B9%E3%81%AF1%E6%96%87%E4%B8%AD%E3%81%AB3%E3%81%A4%E3%81%BE%E3%81%A7)
 - [連続できる最大の漢字長は6文字まで](#%E9%80%A3%E7%B6%9A%E3%81%A7%E3%81%8D%E3%82%8B%E6%9C%80%E5%A4%A7%E3%81%AE%E6%BC%A2%E5%AD%97%E9%95%B7%E3%81%AF6%E6%96%87%E5%AD%97%E3%81%BE%E3%81%A7)
 - [漢数字と算用数字を使い分けます](#%E6%BC%A2%E6%95%B0%E5%AD%97%E3%81%A8%E7%AE%97%E7%94%A8%E6%95%B0%E5%AD%97%E3%82%92%E4%BD%BF%E3%81%84%E5%88%86%E3%81%91%E3%81%BE%E3%81%99)
+- [日付と曜日が矛盾していないかチェックする](#%E6%97%A5%E4%BB%98%E3%81%A8%E6%9B%9C%E6%97%A5%E3%81%8C%E7%9F%9B%E7%9B%BE%E3%81%97%E3%81%A6%E3%81%84%E3%81%AA%E3%81%84%E3%81%8B%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)
+- [よくある英語のスペルミスをチェックする](#%E3%82%88%E3%81%8F%E3%81%82%E3%82%8B%E8%8B%B1%E8%AA%9E%E3%81%AE%E3%82%B9%E3%83%9A%E3%83%AB%E3%83%9F%E3%82%B9%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)
 - [「ですます調」、「である調」を統一します](#%E3%81%A7%E3%81%99%E3%81%BE%E3%81%99%E8%AA%BF%E3%81%A7%E3%81%82%E3%82%8B%E8%AA%BF%E3%82%92%E7%B5%B1%E4%B8%80%E3%81%97%E3%81%BE%E3%81%99)
 - [文末の句点記号として「。」を使います](#%E6%96%87%E6%9C%AB%E3%81%AE%E5%8F%A5%E7%82%B9%E8%A8%98%E5%8F%B7%E3%81%A8%E3%81%97%E3%81%A6%E3%82%92%E4%BD%BF%E3%81%84%E3%81%BE%E3%81%99)
 - [二重否定は使用しない](#%E4%BA%8C%E9%87%8D%E5%90%A6%E5%AE%9A%E3%81%AF%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)
@@ -41,11 +43,19 @@ textlint --preset track README.md
 - [同じ接続詞を連続して使用しない](#%E5%90%8C%E3%81%98%E6%8E%A5%E7%B6%9A%E8%A9%9E%E3%82%92%E9%80%A3%E7%B6%9A%E3%81%97%E3%81%A6%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)
 - [同じ助詞を連続して使用しない](#%E5%90%8C%E3%81%98%E5%8A%A9%E8%A9%9E%E3%82%92%E9%80%A3%E7%B6%9A%E3%81%97%E3%81%A6%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)
 - [UTF8-MAC 濁点を使用しない](#utf8-mac-%E6%BF%81%E7%82%B9%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)
+- [TODOマークを残さない](#todo%E3%83%9E%E3%83%BC%E3%82%AF%E3%82%92%E6%AE%8B%E3%81%95%E3%81%AA%E3%81%84)
+- [無効な制御文字を使用しない](#%E7%84%A1%E5%8A%B9%E3%81%AA%E5%88%B6%E5%BE%A1%E6%96%87%E5%AD%97%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)
+- [括弧やクォーテーションなどの記号のペアの整合性をチェックする](#%E6%8B%AC%E5%BC%A7%E3%82%84%E3%82%AF%E3%82%A9%E3%83%BC%E3%83%86%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AA%E3%81%A9%E3%81%AE%E8%A8%98%E5%8F%B7%E3%81%AE%E3%83%9A%E3%82%A2%E3%81%AE%E6%95%B4%E5%90%88%E6%80%A7%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)
+- [全角と半角アルファベットを混在させない](#%E5%85%A8%E8%A7%92%E3%81%A8%E5%8D%8A%E8%A7%92%E3%82%A2%E3%83%AB%E3%83%95%E3%82%A1%E3%83%99%E3%83%83%E3%83%88%E3%82%92%E6%B7%B7%E5%9C%A8%E3%81%95%E3%81%9B%E3%81%AA%E3%81%84)
+- [サ抜き、サ入れ表現の誤用をチェックする](#%E3%82%B5%E6%8A%9C%E3%81%8D%E3%82%B5%E5%85%A5%E3%82%8C%E8%A1%A8%E7%8F%BE%E3%81%AE%E8%AA%A4%E7%94%A8%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)
 - [感嘆符!！、疑問符?？を使用しない](#%E6%84%9F%E5%98%86%E7%AC%A6%E7%96%91%E5%95%8F%E7%AC%A6%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)
 - [半角カナを使用しない](#%E5%8D%8A%E8%A7%92%E3%82%AB%E3%83%8A%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)
 - [弱い日本語表現を使用しない](#%E5%BC%B1%E3%81%84%E6%97%A5%E6%9C%AC%E8%AA%9E%E8%A1%A8%E7%8F%BE%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%AA%E3%81%84)
 - [同一の単語を間違えて連続しているのをチェックする](#%E5%90%8C%E4%B8%80%E3%81%AE%E5%8D%98%E8%AA%9E%E3%82%92%E9%96%93%E9%81%95%E3%81%88%E3%81%A6%E9%80%A3%E7%B6%9A%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E3%81%AE%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)
 - [よくある日本語の誤用をチェックする](#%E3%82%88%E3%81%8F%E3%81%82%E3%82%8B%E6%97%A5%E6%9C%AC%E8%AA%9E%E3%81%AE%E8%AA%A4%E7%94%A8%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)
+- [不自然なアルファベットを検知する](#%E4%B8%8D%E8%87%AA%E7%84%B6%E3%81%AA%E3%82%A2%E3%83%AB%E3%83%95%E3%82%A1%E3%83%99%E3%83%83%E3%83%88%E3%82%92%E6%A4%9C%E7%9F%A5%E3%81%99%E3%82%8B)
+- [「〜たり〜たりする」をチェックする](#%E3%80%9C%E3%81%9F%E3%82%8A%E3%80%9C%E3%81%9F%E3%82%8A%E3%81%99%E3%82%8B%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)
+- [専門用語のスペルをチェックする](#%E5%B0%82%E9%96%80%E7%94%A8%E8%AA%9E%E3%81%AE%E3%82%B9%E3%83%9A%E3%83%AB%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)
 - [テクニカルワードをチェックする](#%E3%83%86%E3%82%AF%E3%83%8B%E3%82%AB%E3%83%AB%E3%83%AF%E3%83%BC%E3%83%89%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)
 - [表記ゆれをチェックする](#%E8%A1%A8%E8%A8%98%E3%82%86%E3%82%8C%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)
 
@@ -105,6 +115,22 @@ textlint --preset track README.md
 
 ```
 "arabic-kanji-numbers": true,
+```
+
+### 日付と曜日が矛盾していないかチェックする
+> https://github.com/azu/textlint-rule-date-weekday-mismatch
+
+
+```
+"date-weekday-mismatch": true,
+```
+
+### よくある英語のスペルミスをチェックする
+> https://github.com/io-monad/textlint-rule-common-misspellings
+
+
+```
+"common-misspellings": true,
 ```
 
 ### 「ですます調」、「である調」を統一します
@@ -191,6 +217,48 @@ textlint --preset track README.md
 "no-nfd": true,
 ```
 
+### TODOマークを残さない
+> https://github.com/textlint-rule/textlint-rule-no-todo
+
+
+```
+"no-todo": true,
+```
+
+### 無効な制御文字を使用しない
+> https://github.com/textlint-rule/textlint-rule-no-invalid-control-character
+
+
+```
+"no-invalid-control-character": true,
+```
+
+### 括弧やクォーテーションなどの記号のペアの整合性をチェックする
+> https://github.com/textlint-rule/textlint-rule-no-unmatched-pair
+
+
+```
+"no-unmatched-pair": true,
+```
+
+### 全角と半角アルファベットを混在させない
+> https://github.com/textlint-ja/textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet
+
+
+```
+"no-mixed-zenkaku-and-hankaku-alphabet": {
+  "prefer": "半角"
+},
+```
+
+### サ抜き、サ入れ表現の誤用をチェックする
+> https://github.com/textlint-ja/textlint-rule-no-insert-dropping-sa
+
+
+```
+"no-insert-dropping-sa": true,
+```
+
 ### 感嘆符!！、疑問符?？を使用しない
 > https://github.com/azu/textlint-rule-no-exclamation-question-mark
 
@@ -243,6 +311,30 @@ textlint --preset track README.md
 
 ```
 "ja-no-abusage": true,
+```
+
+### 不自然なアルファベットを検知する
+> https://github.com/textlint-ja/textlint-rule-ja-unnatural-alphabet
+
+
+```
+"ja-unnatural-alphabet": true,
+```
+
+### 「〜たり〜たりする」をチェックする
+> https://github.com/textlint-ja/textlint-rule-prefer-tari-tari
+
+
+```
+"prefer-tari-tari": true,
+```
+
+### 専門用語のスペルをチェックする
+> https://github.com/sapegin/textlint-rule-terminology
+
+
+```
+"terminology": true,
 ```
 
 ### テクニカルワードをチェックする

--- a/lib/textlint-rule-preset-track.js
+++ b/lib/textlint-rule-preset-track.js
@@ -12,17 +12,27 @@ module.exports = {
     "no-mix-dearu-desumasu": interopRequire("textlint-rule-no-mix-dearu-desumasu"),
     "ja-no-mixed-period": interopRequire("textlint-rule-ja-no-mixed-period"),
     "arabic-kanji-numbers": jtfRules["2.2.2.算用数字と漢数字の使い分け"],
+    "date-weekday-mismatch": interopRequire("textlint-rule-date-weekday-mismatch"),
+    "common-misspellings": interopRequire("textlint-rule-common-misspellings"),
     "no-doubled-conjunction": interopRequire("textlint-rule-no-doubled-conjunction"),
     "no-doubled-conjunctive-particle-ga": interopRequire("textlint-rule-no-doubled-conjunctive-particle-ga"),
     "no-double-negative-ja": interopRequire("textlint-rule-no-double-negative-ja"),
     "no-doubled-joshi": interopRequire("textlint-rule-no-doubled-joshi"),
     "no-dropping-the-ra": interopRequire("textlint-rule-no-dropping-the-ra"),
     "no-nfd": interopRequire("textlint-rule-no-nfd"),
+    "no-todo": interopRequire("textlint-rule-no-todo"),
+    "no-invalid-control-character": interopRequire("@textlint-rule/textlint-rule-no-invalid-control-character"),
+    "no-unmatched-pair": interopRequire("@textlint-rule/textlint-rule-no-unmatched-pair"),
+    "no-mixed-zenkaku-and-hankaku-alphabet": interopRequire("textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet"),
+    "no-insert-dropping-sa": interopRequire("@textlint-ja/textlint-rule-no-insert-dropping-sa"),
     "no-exclamation-question-mark": interopRequire("textlint-rule-no-exclamation-question-mark"),
     "no-hankaku-kana": interopRequire("textlint-rule-no-hankaku-kana"),
     "ja-no-weak-phrase": interopRequire("textlint-rule-ja-no-weak-phrase"),
     "ja-no-successive-word": interopRequire("textlint-rule-ja-no-successive-word"),
     "ja-no-abusage": interopRequire("textlint-rule-ja-no-abusage"),
+    "ja-unnatural-alphabet": interopRequire("textlint-rule-ja-unnatural-alphabet"),
+    "prefer-tari-tari": interopRequire("textlint-rule-prefer-tari-tari"),
+    "terminology": interopRequire("textlint-rule-terminology"),
     "spellcheck-tech-word": interopRequire("textlint-rule-spellcheck-tech-word"),
     "prh": interopRequire("textlint-rule-prh")
   },
@@ -64,6 +74,14 @@ module.exports = {
     // https://github.com/azu/textlint-rule-preset-JTF-style
     // https://www.jtf.jp/jp/style_guide/styleguide_top.html
     "arabic-kanji-numbers": true,
+
+    // # 日付と曜日が矛盾していないかチェックする
+    // https://github.com/azu/textlint-rule-date-weekday-mismatch
+    "date-weekday-mismatch": true,
+
+    // # よくある英語のスペルミスをチェックする
+    // https://github.com/io-monad/textlint-rule-common-misspellings
+    "common-misspellings": true,
 
     // # 「ですます調」、「である調」を統一します
     // - 見出しは自動
@@ -117,6 +135,28 @@ module.exports = {
     // https://github.com/azu/textlint-rule-no-nfd
     "no-nfd": true,
 
+    // # TODOマークを残さない
+    // https://github.com/textlint-rule/textlint-rule-no-todo
+    "no-todo": true,
+
+    // # 無効な制御文字を使用しない
+    // https://github.com/textlint-rule/textlint-rule-no-invalid-control-character
+    "no-invalid-control-character": true,
+
+    // # 括弧やクォーテーションなどの記号のペアの整合性をチェックする
+    // https://github.com/textlint-rule/textlint-rule-no-unmatched-pair
+    "no-unmatched-pair": true,
+
+    // # 全角と半角アルファベットを混在させない
+    // https://github.com/textlint-ja/textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet
+    "no-mixed-zenkaku-and-hankaku-alphabet": {
+      "prefer": "半角"
+    },
+
+    // # サ抜き、サ入れ表現の誤用をチェックする
+    // https://github.com/textlint-ja/textlint-rule-no-insert-dropping-sa
+    "no-insert-dropping-sa": true,
+
     // # 感嘆符!！、疑問符?？を使用しない
     // 特定の感嘆符または感嘆符を使用する場合は、オプションで許可して利用してください。
     // https://github.com/azu/textlint-rule-no-exclamation-question-mark
@@ -150,6 +190,18 @@ module.exports = {
     // 日本語や技術表現における漢字の誤用などをチェックするルールです。
     // https://github.com/textlint-ja/textlint-rule-ja-no-abusage
     "ja-no-abusage": true,
+
+    // # 不自然なアルファベットを検知する
+    // https://github.com/textlint-ja/textlint-rule-ja-unnatural-alphabet
+    "ja-unnatural-alphabet": true,
+
+    // # 「〜たり〜たりする」をチェックする
+    // https://github.com/textlint-ja/textlint-rule-prefer-tari-tari
+    "prefer-tari-tari": true,
+
+    // # 専門用語のスペルをチェックする
+    // https://github.com/sapegin/textlint-rule-terminology
+    "terminology": true,
 
     // # テクニカルワードをチェックする
     // WEB+DB PRESS用語統一ルールやJavaScript関連の用語などを含んだテクニカルワードをチェックするルールです。

--- a/package.json
+++ b/package.json
@@ -27,11 +27,17 @@
     "preset"
   ],
   "dependencies": {
+    "@textlint-ja/textlint-rule-no-insert-dropping-sa": "^1.0.1",
+    "@textlint-rule/textlint-rule-no-invalid-control-character": "^1.2.0",
+    "@textlint-rule/textlint-rule-no-unmatched-pair": "^1.0.7",
     "interop-require": "^1.0.0",
+    "textlint-rule-common-misspellings": "^1.0.1",
+    "textlint-rule-date-weekday-mismatch": "^1.0.5",
     "textlint-rule-ja-no-abusage": "^1.2.2",
     "textlint-rule-ja-no-mixed-period": "^2.1.1",
     "textlint-rule-ja-no-successive-word": "^1.1.0",
     "textlint-rule-ja-no-weak-phrase": "^1.0.4",
+    "textlint-rule-ja-unnatural-alphabet": "^2.0.1",
     "textlint-rule-max-comma": "^1.0.4",
     "textlint-rule-max-kanji-continuous-len": "^1.1.1",
     "textlint-rule-max-ten": "^2.0.3",
@@ -43,11 +49,15 @@
     "textlint-rule-no-exclamation-question-mark": "^1.0.2",
     "textlint-rule-no-hankaku-kana": "^1.0.2",
     "textlint-rule-no-mix-dearu-desumasu": "^4.0.0",
+    "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "^1.0.1",
     "textlint-rule-no-nfd": "^1.0.1",
+    "textlint-rule-no-todo": "^2.0.1",
+    "textlint-rule-prefer-tari-tari": "^1.0.3",
     "textlint-rule-preset-jtf-style": "^2.3.3",
     "textlint-rule-prh": "^5.2.0",
     "textlint-rule-sentence-length": "^2.1.1",
-    "textlint-rule-spellcheck-tech-word": "^5.0.0"
+    "textlint-rule-spellcheck-tech-word": "^5.0.0",
+    "textlint-rule-terminology": "^1.1.30"
   },
   "devDependencies": {
     "markdown-toc": "^1.2.0",


### PR DESCRIPTION
いくつかのtextlint rulesを追加しました。

以下のルールは、厳しすぎると思い入れませんでした。
- 冗長な表現を禁止するルール [textlint\-ja/textlint\-rule\-ja\-no\-redundant\-expression: 冗長な表現をチェックするtextlintルール](https://github.com/textlint-ja/textlint-rule-ja-no-redundant-expression)
- 表外音訓
  - [lostandfound/textlint\-rule\-ja\-hiragana\-keishikimeishi: Check easy\-to\-read Keishikimeishi\(pronouns\) written in Hiragana than Kanji\.](https://github.com/lostandfound/textlint-rule-ja-hiragana-keishikimeishi)
  - [lostandfound/textlint\-rule\-ja\-hiragana\-daimeishi: Check easy\-to\-read Daimeishi\(pronouns\) written in Hiragana than Kanji\.](https://github.com/lostandfound/textlint-rule-ja-hiragana-daimeishi)
  - [lostandfound/textlint\-rule\-ja\-hiragana\-fukushi: Check easy\-to\-read Fukushi\(adverbs\) written in Hiragana than Kanji\.](https://github.com/lostandfound/textlint-rule-ja-hiragana-fukushi)
  - [lostandfound/textlint\-rule\-ja\-hiragana\-hojodoushi: Check easy\-to\-read Hojodoushi\(auxiliary verbs\) written in Hiragana than Kanji\.](https://github.com/lostandfound/textlint-rule-ja-hiragana-hojodoushi)
