### PR TITLE
Fix prh rule

### DIFF
--- a/lib/prh.yml
+++ b/lib/prh.yml
@@ -1,4 +1,4 @@
 version: 1
 rules:
-  - expected: Track
-    pattern:  /track/ig
+  - expected: てみましょう
+    pattern:  て見ましょう


### PR DESCRIPTION
Fix https://github.com/givery-technology/track-contents-course/issues/52#issuecomment-505650040 , https://github.com/givery-technology/track-contents-course/issues/52#issuecomment-505641839

"track" を使うケースがあるため、prhのルールから除きました。
代わりに、「〜して見ましょう」を「〜してみましょう」に修正するprhルールを追加しました。
（「見て見ましょう」や「やって見ましょう」に対応するため、「てみましょう」にしています。）
