### PR TITLE
Tag/v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "interop-require": "^1.0.0",
     "textlint-rule-common-misspellings": "^1.0.1",
     "textlint-rule-date-weekday-mismatch": "^1.0.5",
-    "textlint-rule-ja-no-abusage": "^1.2.2",
+    "textlint-rule-ja-no-abusage": "^2.0.1",
     "textlint-rule-ja-no-mixed-period": "^2.1.1",
     "textlint-rule-ja-no-successive-word": "^1.1.0",
     "textlint-rule-ja-no-weak-phrase": "^1.0.4",
@@ -46,23 +46,23 @@
     "textlint-rule-no-double-negative-ja": "^1.0.5",
     "textlint-rule-no-doubled-conjunction": "^1.0.2",
     "textlint-rule-no-doubled-conjunctive-particle-ga": "^1.1.0",
-    "textlint-rule-no-doubled-joshi": "^3.5.1",
+    "textlint-rule-no-doubled-joshi": "^3.7.2",
     "textlint-rule-no-dropping-the-ra": "^1.1.2",
     "textlint-rule-no-exclamation-question-mark": "^1.0.2",
     "textlint-rule-no-hankaku-kana": "^1.0.2",
     "textlint-rule-no-mix-dearu-desumasu": "^4.0.0",
     "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "^1.0.1",
-    "textlint-rule-no-nfd": "^1.0.1",
+    "textlint-rule-no-nfd": "^1.0.2",
     "textlint-rule-no-todo": "^2.0.1",
     "textlint-rule-prefer-tari-tari": "^1.0.3",
-    "textlint-rule-preset-jtf-style": "^2.3.3",
-    "textlint-rule-prh": "^5.2.0",
-    "textlint-rule-sentence-length": "^2.1.1",
+    "textlint-rule-preset-jtf-style": "^2.3.4",
+    "textlint-rule-prh": "^5.3.0",
+    "textlint-rule-sentence-length": "^2.2.0",
     "textlint-rule-spellcheck-tech-word": "^5.0.0",
-    "textlint-rule-terminology": "^1.1.30"
+    "textlint-rule-terminology": "^2.0.3"
   },
   "devDependencies": {
     "markdown-toc": "^1.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^7.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-rule-preset-track",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "textlint rule for Track",
   "main": "lib/textlint-rule-preset-track.js",
   "scripts": {


### PR DESCRIPTION
## Update dependencies
- textlint-rule-ja-no-abusage      ^1.2.2  →  ^2.0.1
  - 誤用例35件追加
  - bug fix
- textlint-rule-no-doubled-joshi   ^3.5.1  →  ^3.7.2
  - デフォルトの読点文字として"，"(全角カンマ)を追加
  - 並列助詞は例外として許可
  - 品詞細分類2,3も助詞の一致比較に利用する
  - bug fix
- textlint-rule-no-nfd             ^1.0.1  →  ^1.0.2
  - bug fix, migration
- textlint-rule-preset-jtf-style   ^2.3.3  →  ^2.3.4
  - update yarn.lock
- textlint-rule-prh                ^5.2.0  →  ^5.3.0
  - インラインコードおよびコードブロック中のコメントもチェックできるように。有効にはしていない。
- textlint-rule-sentence-length    ^2.1.1  →  ^2.2.0
  - カウントしない文字列パターンを指定できるように。特に指定はしていない。
  - bug fix
- textlint-rule-terminology       ^1.1.30  →  ^2.0.3
  - bug fix

## Update dev-dependencies
- mocha                            ^6.1.4  →  ^7.0.1

## 備考
`track-contents-course`で動作確認済み。